### PR TITLE
Patch for using bitv with js_of_ocaml

### DIFF
--- a/bitv.ml
+++ b/bitv.ml
@@ -382,7 +382,8 @@ let iteri_true_ntz32 f v =
 let martin_constant = (0x03f79d71b lsl 28) lor 0x4ca8b09 (*0x03f79d71b4ca8b09*)
 let hash64 x = ((martin_constant * x) land max_int) lsr 56
 let ntz_arr64 = Array.make 64 0
-let () = for i = 0 to 62 do ntz_arr64.(hash64 (1 lsl i)) <- i done
+let () = if Sys.word_size >= 64 then
+  for i = 0 to 62 do ntz_arr64.(hash64 (1 lsl i)) <- i done
 let ntz64 x = if x == 0 then 63 else ntz_arr64.(hash64 (x land (-x)))
 
 let iteri_true_ntz64 f v =

--- a/bitv.ml
+++ b/bitv.ml
@@ -41,8 +41,6 @@ let length v = v.length
 
 let bpi = Sys.word_size - 2
 
-let max_length = Sys.max_array_length * bpi
-
 let bit_j = Array.init bpi (fun j -> 1 lsl j)
 let bit_not_j = Array.init bpi (fun j -> max_int - bit_j.(j))
 
@@ -56,11 +54,13 @@ let high_mask = Array.init (succ bpi) (fun j -> low_mask.(j) lsl (bpi-j))
 
 let keep_highest_bits a j = a land high_mask.(j)
 
+let exceeds_max_length n = n / bpi > Sys.max_array_length
+
 (*s Creating and normalizing a bit vector is easy: it is just a matter of
     taking care of the invariant. Copy is immediate. *)
 
 let create n b =
-  if n < 0 || n > max_length then invalid_arg "Bitv.create";
+  if n < 0 || n / bpi > Sys.max_array_length then invalid_arg "Bitv.create";
   let initv = if b then max_int else 0 in
   let r = n mod bpi in
   if r = 0 then

--- a/bitv.mli
+++ b/bitv.mli
@@ -43,9 +43,9 @@ val length : t -> int
 (** [Bitv.length] returns the length (number of elements) of the given
     vector. *)
 
-(** [max_length] is the maximum length of a bit vector (System dependent). *)
-val max_length : int
-
+(** Returns true if the argument exceeds the maximum length of a bit vector
+    (System dependent). *)
+val exceeds_max_length : int -> bool
 
 (** {2 Copies and concatenations.} *)
 

--- a/sieve.ml
+++ b/sieve.ml
@@ -4,7 +4,7 @@
 open Bitv
 
 let sieve1 limit =
-  if limit >= max_length then invalid_arg "first_primes_upto";
+  if exceeds_max_length limit then invalid_arg "first_primes_upto";
   let b = create (limit + 1) true in
   unsafe_set b 0 false;
   unsafe_set b 1 false;
@@ -28,7 +28,7 @@ let () = assert (pop (sieve1 100) = 25)
 open Bitv_string
 
 let sieve2 limit =
-  if limit >= max_length then invalid_arg "first_primes_upto";
+  if exceeds_max_length limit then invalid_arg "first_primes_upto";
   let b = create (limit + 1) true in
   unsafe_set b 0 false;
   unsafe_set b 1 false;


### PR DESCRIPTION
Hi Jean-Christophe,

I've started to use your very helpful library with js_of_ocaml. Unfortunately, this is problematic because (at least on my system) the word size is 32 bits. Here are two commits that make it work. The earliest one is non-controversial (I think). The second one changes the interface and thus potentially breaks existing code. Maybe you can think of a better solution? (I'd be happy to edit the patch.)

Tim.