### PR TITLE
add iter_bin and from_stream_bin

### DIFF
--- a/bitv.ml
+++ b/bitv.ml
@@ -618,7 +618,7 @@ let to_bytes t =
   iter_bin t write;
   Buffer.to_bytes buf
 
-let from_char_stream read =
+let from_stream_bin read =
   let len = Bytes.init 8 (fun _ -> read ()) |> int_of_bytes in
   let bits = create len false in
   let rec loop i byte =
@@ -633,7 +633,7 @@ let from_char_stream read =
 
 let input_bin in_ch =
   let read () = input_char in_ch in
-  from_char_stream read
+  from_stream_bin read
 
 let of_bytes b =
   let read =
@@ -643,7 +643,7 @@ let of_bytes b =
       incr p;
       ret
   in
-  from_char_stream read
+  from_stream_bin read
 
 (* Iteration on all bit vectors of length [n] using a Gray code. *)
 

--- a/bitv.ml
+++ b/bitv.ml
@@ -580,7 +580,7 @@ module M = S(struct let least_first = false end)
 (*s Input/output in a machine-independent format. *)
 
 let bytes_of_int x =
-  Bytes.init 8 (fun i -> Char.chr ((x lsr (8 * i)) land 0xFF))
+  Bytes.init 8 (fun i -> Char.unsafe_chr ((x lsr (8 * i)) land 0xFF))
 
 let int_of_bytes b =
   assert (Bytes.length b = 8);
@@ -595,9 +595,9 @@ let to_char_iter v write =
   let rec loop i pow byte =
     let byte = if unsafe_get v i then byte lor pow else byte in
     if i = len - 1 then
-      write (Char.chr byte)
+      write (Char.unsafe_chr byte)
     else if i mod 8 = 7 then begin
-      write (Char.chr byte);
+      write (Char.unsafe_chr byte);
       loop (i + 1) 1 0
     end else
       loop (i + 1) (pow * 2) byte

--- a/bitv.mli
+++ b/bitv.mli
@@ -204,17 +204,19 @@ end
     For a bit vector of length [n], the number of bytes of this external
     representation is 8+ceil(n/8). *)
 
+val length_bin: t -> int
+
 val output_bin: out_channel -> t -> unit
 val input_bin: in_channel -> t
 
 val to_bytes: t -> bytes
 val of_bytes: bytes -> t
 
-val to_char_iter: t -> (char -> unit) -> unit
-(** [to_char_iter v f] will call [f byte] for each [byte] it intends to write. *)
+val iter_bin: t -> (char -> unit) -> unit
+(** [iter_bin v f] will call [f byte] for each [byte] it intends to write. *)
 
-val of_char_stream: (unit -> char) -> t
-(** [of_char_iter f] will call [f ()] for read the next byte to decode. *)
+val from_stream_bin: (unit -> char) -> t
+(** [from_stream_bin f] will call [f ()] for read the next byte to decode. *)
 
 (** {2 Conversions to and from lists of integers}
 

--- a/bitv.mli
+++ b/bitv.mli
@@ -210,6 +210,12 @@ val input_bin: in_channel -> t
 val to_bytes: t -> bytes
 val of_bytes: bytes -> t
 
+val to_char_iter: t -> (char -> unit) -> unit
+(** [to_char_iter v f] will call [f byte] for each [byte] it intends to write. *)
+
+val of_char_stream: (unit -> char) -> t
+(** [of_char_iter f] will call [f ()] for read the next byte to decode. *)
+
 (** {2 Conversions to and from lists of integers}
 
     The list gives the indices of bits which are set (ie [true]). *)

--- a/bitv.mli
+++ b/bitv.mli
@@ -202,8 +202,7 @@ end
     bytes, in a way that is compact, independent of the machine architecture,
     and independent of the OCaml version.
     For a bit vector of length [n], the number of bytes of this external
-    representation is 4+ceil(n/8) on a 32-bit machine and 8+ceil(n/8) on
-    a 64-bit machine. *)
+    representation is 8+ceil(n/8). *)
 
 val output_bin: out_channel -> t -> unit
 val input_bin: in_channel -> t

--- a/bitv_string.mli
+++ b/bitv_string.mli
@@ -58,6 +58,14 @@ val bw_or  : t -> t -> t
 val bw_xor : t -> t -> t
 val bw_not : t -> t
 
+val length_bin: t -> int
+val output_bin: out_channel -> t -> unit
+val input_bin: in_channel -> t
+val to_bytes: t -> bytes
+val of_bytes: bytes -> t
+val iter_bin: t -> (char -> unit) -> unit
+val from_stream_bin: (unit -> char) -> t
+
 val to_list : t -> int list
 val of_list : int list -> t
 val of_list_with_length : int list -> int -> t


### PR DESCRIPTION
This PR is to expose some functions that were already in the current code to facilitate serialization and deserialization.

- `iter_bin`: exposing this function can avoid some unnecessary overhead due to the conversion between `bytes`, `bigarray`, and other types.
- `from_stream_bin`: the format used by `bitv` has the length information built-in, which is very useful for deserialization, but then it would silently drop the unread portion. There are several ways to work around this, for example encoding length of the format in the enclosing format so that we know how many bytes `bitv` is expecting, but it seems more straightforward to let bitv decide the number of bytes it wishes to consume as it goes. Fortunately, such a function was already in the code.

PS: I am not sure about the function names. In particular, `stream` should probably be replaced by something else.