### PR TITLE
Adding support for in place bitwise operations

### DIFF
--- a/bitv.ml
+++ b/bitv.ml
@@ -213,6 +213,19 @@ let pop v =
    However, one has to take care of normalizing the result of [bwnot]
    which introduces ones in highest significant positions. *)
 
+let[@inline always] bw_and_in_place_internal ~result ~n b1 b2 =
+  for i = 0 to n - 1 do
+    set_byte result i ((byte b1 i) land (byte b2 i))
+  done
+
+let bw_and_in_place ~result v1 v2 =
+  let l = v1.length in
+  if l <> v2.length || l <> result.length then invalid_arg "Bitv.bw_and_in_place";
+  let b1 = v1.bits
+  and b2 = v2.bits in
+  let n = Bytes.length b1 in
+  bw_and_in_place_internal ~result:result.bits ~n b1 b2
+
 let bw_and v1 v2 =
   let l = v1.length in
   if l <> v2.length then invalid_arg "Bitv.bw_and";
@@ -220,10 +233,21 @@ let bw_and v1 v2 =
   and b2 = v2.bits in
   let n = Bytes.length b1 in
   let a = Bytes.make n (Char.chr 0) in
-  for i = 0 to n - 1 do
-    set_byte a i ((byte b1 i) land (byte b2 i))
-  done;
+  bw_and_in_place_internal ~result:a ~n b1 b2;
   { length = l; bits = a }
+
+let[@inline always] bw_or_in_place_internal ~result ~n b1 b2 =
+  for i = 0 to n - 1 do
+    set_byte result i ((byte b1 i) lor (byte b2 i))
+  done
+
+let bw_or_in_place ~result v1 v2 =
+  let l = v1.length in
+  if l <> v2.length || l <> result.length then invalid_arg "Bitv.bw_or_in_place";
+  let b1 = v1.bits
+  and b2 = v2.bits in
+  let n = Bytes.length b1 in
+  bw_or_in_place_internal ~result:result.bits ~n b1 b2
 
 let bw_or v1 v2 =
   let l = v1.length in
@@ -232,33 +256,53 @@ let bw_or v1 v2 =
   and b2 = v2.bits in
   let n = Bytes.length b1 in
   let a = Bytes.make n (Char.chr 0) in
-  for i = 0 to n - 1 do
-    set_byte a i ((byte b1 i) lor (byte b2 i))
-  done;
+  bw_or_in_place_internal ~result:a ~n b1 b2;
   { length = l; bits = a }
+
+let[@inline always] bw_xor_in_place_internal ~result ~n b1 b2 =
+  for i = 0 to n - 1 do
+    set_byte result i ((byte b1 i) lxor (byte b2 i))
+  done
+
+let bw_xor_in_place ~result v1 v2 =
+  let l = v1.length in
+  if l <> v2.length || l <> result.length then invalid_arg "Bitv.bw_xor_in_place";
+  let b1 = v1.bits
+  and b2 = v2.bits in
+  let n = Bytes.length b1 in
+  bw_xor_in_place_internal ~result:result.bits ~n b1 b2
 
 let bw_xor v1 v2 =
   let l = v1.length in
-  if l <> v2.length then invalid_arg "Bitv.bw_or";
+  if l <> v2.length then invalid_arg "Bitv.bw_xor";
   let b1 = v1.bits
   and b2 = v2.bits in
   let n = Bytes.length b1 in
   let a = Bytes.make n (Char.chr 0) in
-  for i = 0 to n - 1 do
-    set_byte a i ((byte b1 i) lxor (byte b2 i))
-  done;
+  bw_xor_in_place_internal ~result:a ~n b1 b2;
   { length = l; bits = a }
+
+let[@inline always] bw_not_in_place_internal ~result ~n b =
+  let a = result.bits in
+  for i = 0 to n - 1 do
+    set_byte a i (255 land (lnot (byte b i)))
+  done;
+  normalize result
+
+let bw_not_in_place ~result v =
+  let l = v.length in
+  if l <> result.length then invalid_arg "Bitv.bw_not_in_place";
+  let b = v.bits in
+  let n = Bytes.length b in
+  bw_not_in_place_internal ~result ~n b
 
 let bw_not v =
   let b = v.bits in
   let n = Bytes.length b in
   let a = Bytes.make n (Char.chr 0) in
-  for i = 0 to n - 1 do
-    set_byte a i (255 land (lnot (byte b i)))
-  done;
-  let r = { length = v.length; bits = a } in
-  normalize r;
-  r
+  let result = { length = v.length; bits = a } in
+  bw_not_in_place_internal ~result ~n b;
+  result
 
 (* Coercions to/from lists of integers *)
 

--- a/bitv.ml
+++ b/bitv.ml
@@ -213,18 +213,18 @@ let pop v =
    However, one has to take care of normalizing the result of [bwnot]
    which introduces ones in highest significant positions. *)
 
-let[@inline always] bw_and_in_place_internal ~result ~n b1 b2 =
+let[@inline always] bw_and_in_place_internal ~dest ~n b1 b2 =
   for i = 0 to n - 1 do
-    set_byte result i ((byte b1 i) land (byte b2 i))
+    set_byte dest i ((byte b1 i) land (byte b2 i))
   done
 
-let bw_and_in_place ~result v1 v2 =
+let bw_and_in_place ~dest v1 v2 =
   let l = v1.length in
-  if l <> v2.length || l <> result.length then invalid_arg "Bitv.bw_and_in_place";
+  if l <> v2.length || l <> dest.length then invalid_arg "Bitv.bw_and_in_place";
   let b1 = v1.bits
   and b2 = v2.bits in
   let n = Bytes.length b1 in
-  bw_and_in_place_internal ~result:result.bits ~n b1 b2
+  bw_and_in_place_internal ~dest:dest.bits ~n b1 b2
 
 let bw_and v1 v2 =
   let l = v1.length in
@@ -233,21 +233,21 @@ let bw_and v1 v2 =
   and b2 = v2.bits in
   let n = Bytes.length b1 in
   let a = Bytes.make n (Char.chr 0) in
-  bw_and_in_place_internal ~result:a ~n b1 b2;
+  bw_and_in_place_internal ~dest:a ~n b1 b2;
   { length = l; bits = a }
 
-let[@inline always] bw_or_in_place_internal ~result ~n b1 b2 =
+let[@inline always] bw_or_in_place_internal ~dest ~n b1 b2 =
   for i = 0 to n - 1 do
-    set_byte result i ((byte b1 i) lor (byte b2 i))
+    set_byte dest i ((byte b1 i) lor (byte b2 i))
   done
 
-let bw_or_in_place ~result v1 v2 =
+let bw_or_in_place ~dest v1 v2 =
   let l = v1.length in
-  if l <> v2.length || l <> result.length then invalid_arg "Bitv.bw_or_in_place";
+  if l <> v2.length || l <> dest.length then invalid_arg "Bitv.bw_or_in_place";
   let b1 = v1.bits
   and b2 = v2.bits in
   let n = Bytes.length b1 in
-  bw_or_in_place_internal ~result:result.bits ~n b1 b2
+  bw_or_in_place_internal ~dest:dest.bits ~n b1 b2
 
 let bw_or v1 v2 =
   let l = v1.length in
@@ -256,21 +256,21 @@ let bw_or v1 v2 =
   and b2 = v2.bits in
   let n = Bytes.length b1 in
   let a = Bytes.make n (Char.chr 0) in
-  bw_or_in_place_internal ~result:a ~n b1 b2;
+  bw_or_in_place_internal ~dest:a ~n b1 b2;
   { length = l; bits = a }
 
-let[@inline always] bw_xor_in_place_internal ~result ~n b1 b2 =
+let[@inline always] bw_xor_in_place_internal ~dest ~n b1 b2 =
   for i = 0 to n - 1 do
-    set_byte result i ((byte b1 i) lxor (byte b2 i))
+    set_byte dest i ((byte b1 i) lxor (byte b2 i))
   done
 
-let bw_xor_in_place ~result v1 v2 =
+let bw_xor_in_place ~dest v1 v2 =
   let l = v1.length in
-  if l <> v2.length || l <> result.length then invalid_arg "Bitv.bw_xor_in_place";
+  if l <> v2.length || l <> dest.length then invalid_arg "Bitv.bw_xor_in_place";
   let b1 = v1.bits
   and b2 = v2.bits in
   let n = Bytes.length b1 in
-  bw_xor_in_place_internal ~result:result.bits ~n b1 b2
+  bw_xor_in_place_internal ~dest:dest.bits ~n b1 b2
 
 let bw_xor v1 v2 =
   let l = v1.length in
@@ -279,30 +279,30 @@ let bw_xor v1 v2 =
   and b2 = v2.bits in
   let n = Bytes.length b1 in
   let a = Bytes.make n (Char.chr 0) in
-  bw_xor_in_place_internal ~result:a ~n b1 b2;
+  bw_xor_in_place_internal ~dest:a ~n b1 b2;
   { length = l; bits = a }
 
-let[@inline always] bw_not_in_place_internal ~result ~n b =
-  let a = result.bits in
+let[@inline always] bw_not_in_place_internal ~dest ~n b =
+  let a = dest.bits in
   for i = 0 to n - 1 do
     set_byte a i (255 land (lnot (byte b i)))
   done;
-  normalize result
+  normalize dest
 
-let bw_not_in_place ~result v =
+let bw_not_in_place ~dest v =
   let l = v.length in
-  if l <> result.length then invalid_arg "Bitv.bw_not_in_place";
+  if l <> dest.length then invalid_arg "Bitv.bw_not_in_place";
   let b = v.bits in
   let n = Bytes.length b in
-  bw_not_in_place_internal ~result ~n b
+  bw_not_in_place_internal ~dest ~n b
 
 let bw_not v =
   let b = v.bits in
   let n = Bytes.length b in
   let a = Bytes.make n (Char.chr 0) in
-  let result = { length = v.length; bits = a } in
-  bw_not_in_place_internal ~result ~n b;
-  result
+  let dest = { length = v.length; bits = a } in
+  bw_not_in_place_internal ~dest ~n b;
+  dest
 
 (* Coercions to/from lists of integers *)
 

--- a/bitv.mli
+++ b/bitv.mli
@@ -194,7 +194,7 @@ val bw_and_in_place : dest:t -> t -> t -> unit
 (** bitwise AND in place into [dest];
     raises [Invalid_argument] if the three vectors do not have the same length *)
 
-val bw_or_in_place  : dest:t -> t -> t -> unit
+val bw_or_in_place : dest:t -> t -> t -> unit
 (** bitwise OR in place into [dest];
     raises [Invalid_argument] if the three vectors do not have the same length *)
 

--- a/bitv.mli
+++ b/bitv.mli
@@ -181,29 +181,29 @@ val rotater : t -> int -> t
 (** {3 Bitwise in place operations.}
 
     This part of the API extends some bitwise operations by making them operate
-    in place, that is mutating a supplied bit vector rather than returning a
-    fresh one.
+    in place, that is mutating a destination bit vector supplied as a labeled
+    argument [dest], rather than returning a fresh one.
 
-    The binary operations support being called with [result] being one of the
+    These in place operations support being called with [dest] being one of the
     operands supplied to the function call.
 
-    For example [bw_and_in_place ~result:a a b] will store in [a] the result of
+    For example [bw_and_in_place ~dest:a a b] will store in [a] the result of
     the operation [bw_and a b]. *)
 
-val bw_and_in_place : result:t -> t -> t -> unit
-(** bitwise AND in place into [result];
+val bw_and_in_place : dest:t -> t -> t -> unit
+(** bitwise AND in place into [dest];
     raises [Invalid_argument] if the three vectors do not have the same length *)
 
-val bw_or_in_place  : result:t -> t -> t -> unit
-(** bitwise OR in place into [result];
+val bw_or_in_place  : dest:t -> t -> t -> unit
+(** bitwise OR in place into [dest];
     raises [Invalid_argument] if the three vectors do not have the same length *)
 
-val bw_xor_in_place : result:t -> t -> t -> unit
-(** bitwise XOR in place into [result];
+val bw_xor_in_place : dest:t -> t -> t -> unit
+(** bitwise XOR in place into [dest];
     raises [Invalid_argument] if the three vectors do not have the same length *)
 
-val bw_not_in_place : result:t -> t -> unit
-(** bitwise NOT in place into [result];
+val bw_not_in_place : dest:t -> t -> unit
+(** bitwise NOT in place into [dest];
     raises [Invalid_argument] if the two vectors do not have the same length *)
 
 (** {2 Test functions} *)

--- a/bitv.mli
+++ b/bitv.mli
@@ -178,6 +178,34 @@ val rotatel : t -> int -> t
 val rotater : t -> int -> t
 (** moves bits from most to least significant with wraparound *)
 
+(** {3 Bitwise in place operations.}
+
+    This part of the API extends some bitwise operations by making them operate
+    in place, that is mutating a supplied bit vector rather than returning a
+    fresh one.
+
+    The binary operations support being called with [result] being one of the
+    operands supplied to the function call.
+
+    For example [bw_and_in_place ~result:a a b] will store in [a] the result of
+    the operation [bw_and a b]. *)
+
+val bw_and_in_place : result:t -> t -> t -> unit
+(** bitwise AND in place into [result];
+    raises [Invalid_argument] if the three vectors do not have the same length *)
+
+val bw_or_in_place  : result:t -> t -> t -> unit
+(** bitwise OR in place into [result];
+    raises [Invalid_argument] if the three vectors do not have the same length *)
+
+val bw_xor_in_place : result:t -> t -> t -> unit
+(** bitwise XOR in place into [result];
+    raises [Invalid_argument] if the three vectors do not have the same length *)
+
+val bw_not_in_place : result:t -> t -> unit
+(** bitwise NOT in place into [result];
+    raises [Invalid_argument] if the two vectors do not have the same length *)
+
 (** {2 Test functions} *)
 
 val all_zeros : t -> bool

--- a/test.ml
+++ b/test.ml
@@ -45,6 +45,35 @@ let s = sub v 2 4
 let () = assert (equal (bw_not (bw_not s)) s)
 let () = assert (equal (bw_and e e) e)
 
+(* bitwise in place operations *)
+let va = init 10 (fun i -> i mod 2 = 0)
+let vb = init 10 (fun i -> i mod 4 = 0)
+let vc = create 10 false
+let ve = create 3 false
+let () =
+  assert (to_string va = "0101010101");
+  assert (to_string vb = "0100010001");
+  bw_and_in_place ~dest:vc va vb;
+  assert (equal vc (bw_and va vb));
+  assert (equal vc vb);
+  (try bw_and_in_place ~dest:ve va vb; assert false
+   with Invalid_argument msg -> assert (msg = "Bitv.bw_and_in_place"));
+  bw_or_in_place ~dest:vc va vb;
+  assert (equal vc (bw_or va vb));
+  assert (equal vc va);
+  (try bw_or_in_place ~dest:ve va vb; assert false
+   with Invalid_argument msg -> assert (msg = "Bitv.bw_or_in_place"));
+  bw_xor_in_place ~dest:vc va vb;
+  assert (equal vc (bw_xor va vb));
+  assert (to_string vc = "0001000100");
+  (try bw_xor_in_place ~dest:ve va vb; assert false
+   with Invalid_argument msg -> assert (msg = "Bitv.bw_xor_in_place"));
+  bw_not_in_place ~dest:vc va;
+  assert (to_string vc = "1010101010");
+  (try bw_not_in_place ~dest:ve va; assert false
+   with Invalid_argument msg -> assert (msg = "Bitv.bw_not_in_place"));
+  ()
+
 (* Tanimoto score *)
 let () =
   let b0 = create 10 false in
@@ -235,6 +264,10 @@ let () = assert (equal (bw_or v ones) ones)
 let () = assert (equal (bw_and v ones) v)
 let () = assert (equal (bw_xor v zeros) v)
 let () = assert (equal (bw_xor v ones) (bw_not v))
+let () =
+  let dest = create 30 false in
+  bw_not_in_place ~dest v;
+  assert (equal (bw_xor v ones) dest)
 
 (* fill overflow *)
 let () =


### PR DESCRIPTION
Implement some support for in place bit-wise operations as discussed in issue #35 .

Incidentally this also fixed a typo in the invalid_argument message of `bw_xor`.