### PR TITLE
Rename label dest into dst in in_place operations

### DIFF
--- a/bitv.ml
+++ b/bitv.ml
@@ -230,18 +230,18 @@ let pop v =
    However, one has to take care of normalizing the result of [bwnot]
    which introduces ones in highest significant positions. *)
 
-let[@inline always] bw_and_in_place_internal ~dest ~n b1 b2 =
+let[@inline always] bw_and_in_place_internal ~dst ~n b1 b2 =
   for i = 0 to n - 1 do
-    set_byte dest i ((byte b1 i) land (byte b2 i))
+    set_byte dst i ((byte b1 i) land (byte b2 i))
   done
 
-let bw_and_in_place ~dest v1 v2 =
+let bw_and_in_place ~dst v1 v2 =
   let l = v1.length in
-  if l <> v2.length || l <> dest.length then invalid_arg "Bitv.bw_and_in_place";
+  if l <> v2.length || l <> dst.length then invalid_arg "Bitv.bw_and_in_place";
   let b1 = v1.bits
   and b2 = v2.bits in
   let n = Bytes.length b1 in
-  bw_and_in_place_internal ~dest:dest.bits ~n b1 b2
+  bw_and_in_place_internal ~dst:dst.bits ~n b1 b2
 
 let bw_and v1 v2 =
   let l = v1.length in
@@ -250,21 +250,21 @@ let bw_and v1 v2 =
   and b2 = v2.bits in
   let n = Bytes.length b1 in
   let a = Bytes.make n (Char.chr 0) in
-  bw_and_in_place_internal ~dest:a ~n b1 b2;
+  bw_and_in_place_internal ~dst:a ~n b1 b2;
   { length = l; bits = a }
 
-let[@inline always] bw_or_in_place_internal ~dest ~n b1 b2 =
+let[@inline always] bw_or_in_place_internal ~dst ~n b1 b2 =
   for i = 0 to n - 1 do
-    set_byte dest i ((byte b1 i) lor (byte b2 i))
+    set_byte dst i ((byte b1 i) lor (byte b2 i))
   done
 
-let bw_or_in_place ~dest v1 v2 =
+let bw_or_in_place ~dst v1 v2 =
   let l = v1.length in
-  if l <> v2.length || l <> dest.length then invalid_arg "Bitv.bw_or_in_place";
+  if l <> v2.length || l <> dst.length then invalid_arg "Bitv.bw_or_in_place";
   let b1 = v1.bits
   and b2 = v2.bits in
   let n = Bytes.length b1 in
-  bw_or_in_place_internal ~dest:dest.bits ~n b1 b2
+  bw_or_in_place_internal ~dst:dst.bits ~n b1 b2
 
 let bw_or v1 v2 =
   let l = v1.length in
@@ -273,21 +273,21 @@ let bw_or v1 v2 =
   and b2 = v2.bits in
   let n = Bytes.length b1 in
   let a = Bytes.make n (Char.chr 0) in
-  bw_or_in_place_internal ~dest:a ~n b1 b2;
+  bw_or_in_place_internal ~dst:a ~n b1 b2;
   { length = l; bits = a }
 
-let[@inline always] bw_xor_in_place_internal ~dest ~n b1 b2 =
+let[@inline always] bw_xor_in_place_internal ~dst ~n b1 b2 =
   for i = 0 to n - 1 do
-    set_byte dest i ((byte b1 i) lxor (byte b2 i))
+    set_byte dst i ((byte b1 i) lxor (byte b2 i))
   done
 
-let bw_xor_in_place ~dest v1 v2 =
+let bw_xor_in_place ~dst v1 v2 =
   let l = v1.length in
-  if l <> v2.length || l <> dest.length then invalid_arg "Bitv.bw_xor_in_place";
+  if l <> v2.length || l <> dst.length then invalid_arg "Bitv.bw_xor_in_place";
   let b1 = v1.bits
   and b2 = v2.bits in
   let n = Bytes.length b1 in
-  bw_xor_in_place_internal ~dest:dest.bits ~n b1 b2
+  bw_xor_in_place_internal ~dst:dst.bits ~n b1 b2
 
 let bw_xor v1 v2 =
   let l = v1.length in
@@ -296,30 +296,30 @@ let bw_xor v1 v2 =
   and b2 = v2.bits in
   let n = Bytes.length b1 in
   let a = Bytes.make n (Char.chr 0) in
-  bw_xor_in_place_internal ~dest:a ~n b1 b2;
+  bw_xor_in_place_internal ~dst:a ~n b1 b2;
   { length = l; bits = a }
 
-let[@inline always] bw_not_in_place_internal ~dest ~n b =
-  let a = dest.bits in
+let[@inline always] bw_not_in_place_internal ~dst ~n b =
+  let a = dst.bits in
   for i = 0 to n - 1 do
     set_byte a i (255 land (lnot (byte b i)))
   done;
-  normalize dest
+  normalize dst
 
-let bw_not_in_place ~dest v =
+let bw_not_in_place ~dst v =
   let l = v.length in
-  if l <> dest.length then invalid_arg "Bitv.bw_not_in_place";
+  if l <> dst.length then invalid_arg "Bitv.bw_not_in_place";
   let b = v.bits in
   let n = Bytes.length b in
-  bw_not_in_place_internal ~dest ~n b
+  bw_not_in_place_internal ~dst ~n b
 
 let bw_not v =
   let b = v.bits in
   let n = Bytes.length b in
   let a = Bytes.make n (Char.chr 0) in
-  let dest = { length = v.length; bits = a } in
-  bw_not_in_place_internal ~dest ~n b;
-  dest
+  let dst = { length = v.length; bits = a } in
+  bw_not_in_place_internal ~dst ~n b;
+  dst
 
 (* Coercions to/from lists of integers *)
 

--- a/bitv.mli
+++ b/bitv.mli
@@ -186,28 +186,28 @@ val rotater : t -> int -> t
 
     This part of the API extends some bitwise operations by making them operate
     in place, that is mutating a destination bit vector supplied as a labeled
-    argument [dest], rather than returning a fresh one.
+    argument [dst], rather than returning a fresh one.
 
-    These in place operations support being called with [dest] being one of the
+    These in place operations support being called with [dst] being one of the
     operands supplied to the function call.
 
-    For example [bw_and_in_place ~dest:a a b] will store in [a] the result of
+    For example [bw_and_in_place ~dst:a a b] will store in [a] the result of
     the operation [bw_and a b]. *)
 
-val bw_and_in_place : dest:t -> t -> t -> unit
-(** bitwise AND in place into [dest];
+val bw_and_in_place : dst:t -> t -> t -> unit
+(** bitwise AND in place into [dst];
     raises [Invalid_argument] if the three vectors do not have the same length *)
 
-val bw_or_in_place : dest:t -> t -> t -> unit
-(** bitwise OR in place into [dest];
+val bw_or_in_place : dst:t -> t -> t -> unit
+(** bitwise OR in place into [dst];
     raises [Invalid_argument] if the three vectors do not have the same length *)
 
-val bw_xor_in_place : dest:t -> t -> t -> unit
-(** bitwise XOR in place into [dest];
+val bw_xor_in_place : dst:t -> t -> t -> unit
+(** bitwise XOR in place into [dst];
     raises [Invalid_argument] if the three vectors do not have the same length *)
 
-val bw_not_in_place : dest:t -> t -> unit
-(** bitwise NOT in place into [dest];
+val bw_not_in_place : dst:t -> t -> unit
+(** bitwise NOT in place into [dst];
     raises [Invalid_argument] if the two vectors do not have the same length *)
 
 (** {2 Test functions} *)

--- a/test.ml
+++ b/test.ml
@@ -53,24 +53,24 @@ let ve = create 3 false
 let () =
   assert (to_string va = "0101010101");
   assert (to_string vb = "0100010001");
-  bw_and_in_place ~dest:vc va vb;
+  bw_and_in_place ~dst:vc va vb;
   assert (equal vc (bw_and va vb));
   assert (equal vc vb);
-  (try bw_and_in_place ~dest:ve va vb; assert false
+  (try bw_and_in_place ~dst:ve va vb; assert false
    with Invalid_argument msg -> assert (msg = "Bitv.bw_and_in_place"));
-  bw_or_in_place ~dest:vc va vb;
+  bw_or_in_place ~dst:vc va vb;
   assert (equal vc (bw_or va vb));
   assert (equal vc va);
-  (try bw_or_in_place ~dest:ve va vb; assert false
+  (try bw_or_in_place ~dst:ve va vb; assert false
    with Invalid_argument msg -> assert (msg = "Bitv.bw_or_in_place"));
-  bw_xor_in_place ~dest:vc va vb;
+  bw_xor_in_place ~dst:vc va vb;
   assert (equal vc (bw_xor va vb));
   assert (to_string vc = "0001000100");
-  (try bw_xor_in_place ~dest:ve va vb; assert false
+  (try bw_xor_in_place ~dst:ve va vb; assert false
    with Invalid_argument msg -> assert (msg = "Bitv.bw_xor_in_place"));
-  bw_not_in_place ~dest:vc va;
+  bw_not_in_place ~dst:vc va;
   assert (to_string vc = "1010101010");
-  (try bw_not_in_place ~dest:ve va; assert false
+  (try bw_not_in_place ~dst:ve va; assert false
    with Invalid_argument msg -> assert (msg = "Bitv.bw_not_in_place"));
   ()
 
@@ -265,9 +265,9 @@ let () = assert (equal (bw_and v ones) v)
 let () = assert (equal (bw_xor v zeros) v)
 let () = assert (equal (bw_xor v ones) (bw_not v))
 let () =
-  let dest = create 30 false in
-  bw_not_in_place ~dest v;
-  assert (equal (bw_xor v ones) dest)
+  let dst = create 30 false in
+  bw_not_in_place ~dst v;
+  assert (equal (bw_xor v ones) dst)
 
 (* fill overflow *)
 let () =


### PR DESCRIPTION
I didn't think about this earlier, but looking at OCaml stdlib's `ArrayLabels` and `StringLabels` I noticed the label is called `dst` for in place operations (such as [blit](https://github.com/ocaml/ocaml/blob/ec88aacdab329e70418287b425eb1dd710cc4973/stdlib/arrayLabels.mli#L139)). The `dst` label is also used in [base](https://github.com/janestreet/base/blob/01857ea5364018edb77460517872164f501d1091/src/blit_intf.ml#L11).

I looked at sherlocode too (example of [query](https://sherlocode.com/?q=%7Edst%3A) `https://sherlocode.com/?q=%7Edst%3A`):

label | # hits
--------|--------
~dst: | 882
~dest:  | 147

Based on this I'd like to propose to also use that name `dst` in `Bitv` (rename from `dest` before cutting the next release).

What do you think?